### PR TITLE
chore: fix typos suggested by typos-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ All notable changes to the Koopa will be documented in this file.
 
 ### Fixed
 
-* Fault about creating/initializing `Parser` when error occurrs in `Lexer`.
+* Fault about creating/initializing `Parser` when error occurs in `Lexer`.
 
 ## 0.0.3 - 2022-01-05
 

--- a/koopa/src/back/koopa.rs
+++ b/koopa/src/back/koopa.rs
@@ -7,7 +7,7 @@ use crate::ir::values::*;
 use crate::ir::{BasicBlock, Program, Type, TypeKind, Value, ValueKind};
 use std::io::{Result, Write};
 
-/// Visitor for generating the in-memeory form Koopa IR program into
+/// Visitor for generating the in-memory form Koopa IR program into
 /// the text form.
 #[derive(Default)]
 pub struct Visitor;

--- a/koopa/src/front/ast.rs
+++ b/koopa/src/front/ast.rs
@@ -143,7 +143,7 @@ impl FunType {
   }
 }
 
-/// Symbol refernce.
+/// Symbol reference.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SymbolRef {
   pub symbol: String,

--- a/koopa/src/front/builder.rs
+++ b/koopa/src/front/builder.rs
@@ -683,7 +683,7 @@ impl Builder {
     Ok(self.dfg_mut(func).new_value().binary(ast.op, lhs, rhs))
   }
 
-  /// Generates branchs.
+  /// Generates branches.
   fn generate_branch(
     &mut self,
     func: Function,

--- a/koopa/src/front/span.rs
+++ b/koopa/src/front/span.rs
@@ -211,7 +211,7 @@ impl Span {
           msg += "s";
         }
       }
-      // seperator
+      // separator
       if gs.err_num != 0 && gs.warn_num != 0 {
         msg += " and ";
       }

--- a/koopa/src/opt/passman.rs
+++ b/koopa/src/opt/passman.rs
@@ -5,7 +5,7 @@ use crate::opt::pass::Pass;
 
 /// The Koopa IR pass manager.
 ///
-/// Pass manager manages all registed passes, and processes the input
+/// Pass manager manages all registered passes, and processes the input
 /// IR program by using registered passes.
 #[derive(Default)]
 pub struct PassManager {

--- a/libkoopa/src/raw/builder.rs
+++ b/libkoopa/src/raw/builder.rs
@@ -113,10 +113,10 @@ where
 
 /// Trait for building raw structures from Koopa IR entities.
 trait BuildRaw {
-  /// The type of builded raw structure.
+  /// The type of built raw structure.
   type Raw;
 
-  /// Kind of the builded raw item.
+  /// Kind of the built raw item.
   const KIND: RawSliceItemKind = RawSliceItemKind::Unknown;
 
   /// Builds a new raw structure.


### PR DESCRIPTION
I have to say, the typos are very rare! There little work to be done actually.

Perhaps a better question is whether `typos-cli` should be integrated into CI.